### PR TITLE
Update MoviesController.php

### DIFF
--- a/app/Controller/MoviesController.php
+++ b/app/Controller/MoviesController.php
@@ -46,7 +46,7 @@ class MoviesController extends AppController {
     						array('Movie.description LIKE' => '%' . $value . '%')
 						);
 					} else {
-						$conditions[$name] = $value;
+						$conditions['Movie.'.$name] = $value;
 					}					
 					$this->request->data['Filter'][$name] = $value;	
 				}


### PR DESCRIPTION
In more complex queries the lack of specification causes a Integrity constraint violation: 1052 in your database. This is because the Where clause becomes ambiguous. Specifying 'Movie.'[$name] ensures that the constructed SQL statement is more specific so that in complex statements the ambiguity issue is addressed. (In my project, my equivalent of Movies was BTMHM)
